### PR TITLE
Add environment check to ensure site is using postgres.

### DIFF
--- a/environment.xml
+++ b/environment.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<COMPATIBILITY_MATRIX>
+    <PLUGIN name="search_postgresfulltext">
+        <CUSTOM_CHECKS>
+            <CUSTOM_CHECK file="search/engine/postgresfulltext/environmentchecks.php" function="search_postgresfulltext_check_database" level="required">
+                <FEEDBACK>
+                    <ON_ERROR message="postgreswarning" plugin="search_postgresfulltext" />
+                </FEEDBACK>
+            </CUSTOM_CHECK>
+        </CUSTOM_CHECKS>
+    </PLUGIN>
+</COMPATIBILITY_MATRIX>

--- a/environmentchecks.php
+++ b/environmentchecks.php
@@ -1,0 +1,41 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Functions used during install to check environment.
+ *
+ * @package    search_postgresfulltext
+ * @copyright  2017 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Check if site using is using postgres.
+ *
+ * @param environment_results $result object to update, if relevant.
+ * @return environment_results|null updated results or null.
+ */
+function search_postgresfulltext_check_database(environment_results $result) {
+    global $CFG;
+    if ($CFG->dbtype !== 'pgsql') {
+        $result->setInfo('You must be using PostgreSQL.');
+        $result->setStatus(false);
+        return $result;
+    }
+    return null;
+}

--- a/lang/en/search_postgresfulltext.php
+++ b/lang/en/search_postgresfulltext.php
@@ -32,3 +32,4 @@ $string['maxindexfilekb'] = 'Maximum file size to index (kB)';
 $string['maxindexfilekb_help'] = 'Files larger than this number of kilobytes will not be included in search indexing. If set to zero, files of any size will be indexed.';
 $string['tikaurl'] = 'Tika URL';
 $string['tikaurl_help'] = 'URL to the Apache Tika Server, including the port number e.g. http://localhost:9998';
+$string['postgreswarning'] = 'It has been detected that you are not using PostgreSQL - this plugin does not work on other database types.';


### PR DESCRIPTION
I figure we should probably prevent install on other db types - might save some people asking why it isn't working on an unsupported db....