### PR TITLE
Add setting for websearch method.

### DIFF
--- a/lang/en/search_postgresfulltext.php
+++ b/lang/en/search_postgresfulltext.php
@@ -25,6 +25,10 @@
 $string['pluginname'] = 'Postgres Full Text';
 $string['searchinfo'] = 'Search queries';
 $string['searchinfo_help'] = 'Enter the search query.';
+$string['searchmethod'] = 'Search method';
+$string['searchmethod_help'] = 'Postgres supports a number of different searching options - use "simple" for basic search functions, or "Web search" method to allow operators like quoted text for phrase searching.';
+$string['searchmethod_simple'] = 'Simple';
+$string['searchmethod_websearch'] = 'Web search';
 $string['fileindexsettings'] = 'File indexing settings';
 $string['fileindexing'] = 'Enable file indexing';
 $string['fileindexing_help'] = 'Enable indexing of files if an Apache Tika server is available.';

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,6 @@ if ($ADMIN->fulltree) {
 
     if (!during_initial_install()) {
 
-
         $settings->add(new admin_setting_heading('search_postgresfulltext_fileindexing',
                 new lang_string('fileindexsettings', 'search_postgresfulltext'), ''));
 
@@ -43,5 +42,12 @@ if ($ADMIN->fulltree) {
         $settings->add(new admin_setting_configtext('search_postgresfulltext/maxindexfilekb',
                 new lang_string('maxindexfilekb', 'search_postgresfulltext'),
                 new lang_string('maxindexfilekb_help', 'search_postgresfulltext'), '10000', PARAM_INT));
+
+        $options = ['simple' => new lang_string('searchmethod_simple', 'search_postgresfulltext'),
+                    'websearch' => new lang_string('searchmethod_websearch', 'search_postgresfulltext')];
+
+        $settings->add(new admin_setting_configselect('search_postgresfulltext/searchmethod',
+                new lang_string('searchmethod', 'search_postgresfulltext'),
+                new lang_string('searchmethod', 'search_postgresfulltext'), 'simple', $options));
     }
 }


### PR DESCRIPTION
Hey @matt-catalyst - I wrote this initially to test this, but after testing it (it works) - I couldn't think of a reason this should be a setting, and maybe we should make it always use websearch_to_tsquery

thoughts?