### PR TITLE
[T19] Replace deprecated testcase classes with core_phpunit

### DIFF
--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot . '/search/tests/fixtures/mock_search_area.php');
  * @copyright   2017 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class search_postgresfulltext_engine_testcase extends advanced_testcase {
+class search_postgresfulltext_engine_testcase extends \core_phpunit\testcase {
 
     /**
      * @var \core_search::manager


### PR DESCRIPTION
Adds a fix so unit tests can run with Tōtara 19.

I created this MR against the Tōtara compatible branch but it'll likely need a new TOTARA_19_STABLE branch.