### PR TITLE
match test classname to filename

### DIFF
--- a/tests/engine_test.php
+++ b/tests/engine_test.php
@@ -35,7 +35,7 @@ require_once($CFG->dirroot . '/search/tests/fixtures/mock_search_area.php');
  * @copyright   2017 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class search_postgresfulltext_engine_testcase extends advanced_testcase {
+class search_postgresfulltext_engine_test extends advanced_testcase {
 
     /**
      * @var \core_search::manager


### PR DESCRIPTION
For runtests in Moodle 5.0
Resolves "Class … could not be found" error.