### PR TITLE
[MDL 4.4] Implement unaccented search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ The following features are provided by this plugin:
 * Group support (new in Moodle 3.5)
 * Ordering by course and context (new in Moodle 3.5)
 
-## Supported Moodle Versions
-This plugin currently supports Moodle:
+## Supported Versions
 
-* 3.1
-* 3.4
-* 3.5
-* 3.6
-* 3.9
-* 4.0
+| Moodle version    | Branch             |
+| ----------------- | ------------------ |
+| Moodle 4.4+       | `MOODLE_404_STABLE`|
+| Moodle 3.1 to 4.3 | `main`             |
+| Totara 19         | `TOTARA_19_STABLE` |
+| Totara up to 18   | `main`             |
 
 ## Requirements
 

--- a/classes/engine.php
+++ b/classes/engine.php
@@ -112,10 +112,13 @@ class engine extends \core_search\engine {
         $highlightopen = self::HIGHLIGHT_START;
         $highlightclose = self::HIGHLIGHT_END;
 
-        $title = "ts_headline(x.title, websearch_to_tsquery(?), 'StartSel=$highlightopen, StopSel=$highlightclose') AS title";
+        // Define dictionary to be used
+        $dict = "'en'";
+
+        $title = "ts_headline(" . $dict . ", x.title, websearch_to_tsquery(" . $dict . ", ?), 'StartSel=$highlightopen, StopSel=$highlightclose') AS title";
         $fullselectparams[] = $data->q;
 
-        $content = "ts_headline(x.content, websearch_to_tsquery(?), 'StartSel=$highlightopen, StopSel=$highlightclose') AS content";
+        $content = "ts_headline(" . $dict . ", x.content, websearch_to_tsquery(" . $dict . ", ?), 'StartSel=$highlightopen, StopSel=$highlightclose') AS content";
         $fullselectparams[] = $data->q;
 
         // Fulltext ranking SQL fragment.
@@ -140,9 +143,9 @@ class engine extends \core_search\engine {
 
         $rank = "(
                     GREATEST (
-                        ts_rank(fulltextindex, websearch_to_tsquery(?)),
+                        ts_rank(fulltextindex, websearch_to_tsquery(" . $dict . ", ?)),
                         MAX(
-                            ts_rank(filefulltextindex, websearch_to_tsquery(?))
+                            ts_rank(filefulltextindex, websearch_to_tsquery(" . $dict . ", ?))
                         )
                     )
                     $courseboostsql $contextboostsql
@@ -290,9 +293,9 @@ class engine extends \core_search\engine {
 
         // And finally the main query after applying all AND filters.
         if (!empty($data->q)) {
-            $whereands[] = "t.fulltextindex @@ websearch_to_tsquery(?) ";
+            $whereands[] = "t.fulltextindex @@ websearch_to_tsquery(" . $dict . ", ?) ";
             $whereparams[] = $data->q;
-            $fileands[] = " f.fulltextindex @@ websearch_to_tsquery(?) ";
+            $fileands[] = " f.fulltextindex @@ websearch_to_tsquery(" . $dict . ", ?) ";
             $fileparams[] = $data->q;
         }
 
@@ -385,6 +388,9 @@ class engine extends \core_search\engine {
     public function add_document($document, $fileindexing = false) {
         global $DB;
 
+        // Define dictionary to be used
+        $dict = "'en'";
+
         $doc = (object)$document->export_for_engine();
 
         $doc->docid = $doc->id;
@@ -400,10 +406,10 @@ class engine extends \core_search\engine {
             }
 
             $sql = "UPDATE {search_postgresfulltext} SET fulltextindex =
-                        setweight(to_tsvector(coalesce(title, '')), 'A') ||
-                        setweight(to_tsvector(coalesce(content, '')), 'B') ||
-                        setweight(to_tsvector(coalesce(description1, '')), 'C') ||
-                        setweight(to_tsvector(coalesce(description2, '')), 'C')
+                        setweight(to_tsvector(" . $dict . ", coalesce(title, '')), 'A') ||
+                        setweight(to_tsvector(" . $dict . ", coalesce(content, '')), 'B') ||
+                        setweight(to_tsvector(" . $dict . ", coalesce(description1, '')), 'C') ||
+                        setweight(to_tsvector(" . $dict . ", coalesce(description2, '')), 'C')
                     WHERE id = ? ";
 
             $DB->execute($sql, array($id));
@@ -584,6 +590,9 @@ class engine extends \core_search\engine {
     protected function add_stored_file($document, $storedfile) {
         global $DB, $CFG;
 
+        // Define dictionary to be used
+        $dict = "'en'";
+
         if ($storedfile->get_filesize() > ($this->config->maxindexfilekb * 1024) || $this->config->maxindexfilekb == 0 ) {
             echo "Skipping ".$storedfile->get_filename()." larger than {$this->config->maxindexfilekb} KB\n";
             return true;
@@ -602,7 +611,7 @@ class engine extends \core_search\engine {
         try {
             $sql = "UPDATE {search_postgresfulltext_file}
                     SET title = :title, fileid = :fileid, modified = :modified, filecontenthash = :filecontenthash,
-                        fulltextindex = setweight(to_tsvector(:textdoc), 'B') || setweight(to_tsvector(:texttitle), 'A')
+                        fulltextindex = setweight(to_tsvector(" . $dict . ", :textdoc), 'B') || setweight(to_tsvector(" . $dict . ", :texttitle), 'A')
                     WHERE id = :id";
 
             $params = array(

--- a/db/install.php
+++ b/db/install.php
@@ -42,4 +42,12 @@ function xmldb_search_postgresfulltext_install() {
     $DB->execute("CREATE INDEX {search_postgresfulltext_file_index}
                  ON {search_postgresfulltext_file} USING GIN (fulltextindex)");
 
+    $DB->execute("CREATE EXTENSION IF NOT EXISTS unaccent");
+
+    $DB->execute("DROP TEXT SEARCH CONFIGURATION IF EXISTS en");
+
+    $DB->execute("CREATE TEXT SEARCH CONFIGURATION en ( COPY = english)");
+
+    $DB->execute("ALTER TEXT SEARCH CONFIGURATION en
+                ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem");
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -55,6 +55,21 @@ function xmldb_search_postgresfulltext_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2018040400, 'search', 'postgresfulltext');
     }
 
+    if ($oldversion < 2025052500) {
+
+        $DB->execute("CREATE EXTENSION IF NOT EXISTS unaccent");
+
+        $DB->execute("DROP TEXT SEARCH CONFIGURATION IF EXISTS en");
+
+        $DB->execute("CREATE TEXT SEARCH CONFIGURATION en ( COPY = english)");
+
+        $DB->execute("ALTER TEXT SEARCH CONFIGURATION en
+                    ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem");
+
+        // Postgresfulltext savepoint reached.
+        upgrade_plugin_savepoint(true, 2025052500, 'search', 'postgresfulltext');
+    }
+
     return true;
 
 }

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018051601;
-$plugin->requires = 2017051509;
+$plugin->version = 2025052500;
+$plugin->requires = 2024042209;
 $plugin->component = 'search_postgresfulltext';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '1.2 (Build 2018122700)';


### PR DESCRIPTION
For the install/upgrade steps to run, Postgres 13 is required. I raised the required version to 4.4 which the first version of Moodle not supporting pg versions below 13.

I didn't change the plugin release value.